### PR TITLE
Update help text

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help-includes.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help-includes.html
@@ -23,7 +23,7 @@
   -->
 
 <div>
-    Comma- or space-separated list of patterns of files/directories to be copied
+    Comma-separated list of patterns of files/directories to be copied
     from the slave node back to the master one. See the
     <a href="http://ant.apache.org/manual/Types/fileset.html">@includes of
     Ant fileset</a> for the exact format. The base directory is the


### PR DESCRIPTION
Remove 'space-separated' from help text, only comma works.

https://github.com/jenkinsci/copy-to-slave-plugin/blob/master/src/main/java/com/michelin/cio/hudson/plugins/copytoslave/MyFilePath.java#L106 calls `Util.createFileSet()` which in turn uses a StringTokenizer with only a comma as the delimiter (https://github.com/jenkinsci/jenkins/blob/master/core/src/main/java/hudson/Util.java#L1083).

This also makes the text consistent with the `CopyToSlaveBuildWrapper` help text: https://github.com/jenkinsci/copy-to-slave-plugin/blob/master/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToSlaveBuildWrapper/help-includes.html
