### PR TITLE
Avoids unnecessary wait for a checkpoint with concurrent build.

### DIFF
--- a/src/main/java/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier.java
+++ b/src/main/java/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier.java
@@ -123,7 +123,7 @@ public class CopyToMasterNotifier extends Notifier {
     }
     
     public BuildStepMonitor getRequiredMonitorService() {
-        return BuildStepMonitor.BUILD;
+        return BuildStepMonitor.NONE;
     }
 
     @Extension


### PR DESCRIPTION
During concurrent build on a slave, we sometime noticed entries "waiting for a checkpoint" in the log. Because this plugin is not calling any getPreviousXxxx() function nor is using any Actions, BuildStepMonitor.NONE should be enough. See getRequiredMonitorService() at "http://javadoc.jenkins-ci.org/hudson/tasks/BuildStep.html#getRequiredMonitorService()". Our build of the plugin has been running for a week with no problem and no more wait.
