### PR TITLE
Replace esclave with agent in copy-to-slave-plugin (fr)

### DIFF
--- a/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help-includes_fr.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help-includes_fr.html
@@ -24,7 +24,7 @@
 
 <div>
     Liste de patterns de fichiers/r&eacute;pertoires (s&eacute;par&eacute;s par
-    des espaces ou des virgules) &agrave; copier depuis le noeud esclave vers le
+    des espaces ou des virgules) &agrave; copier depuis le noeud agent vers le
     noeud ma&icirc;tre. Voir les <a href="http://ant.apache.org/manual/Types/fileset.html">
     @includes d'un fileset Ant</a> pour le format exact. Le r&eacute;pertoire
     de base est le <a href="ws/">workspace</a>.

--- a/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help_fr.html
+++ b/src/main/resources/com/michelin/cio/hudson/plugins/copytoslave/CopyToMasterNotifier/help_fr.html
@@ -23,8 +23,8 @@
   -->
 
 <div>
-    Quand un build s'ex&eacute;cute sur un noeud esclave, copie un ensemble de
-    fichiers  depuis ce noeud esclave vers le noeud ma&icirc;tre.
+    Quand un build s'ex&eacute;cute sur un noeud agent, copie un ensemble de
+    fichiers  depuis ce noeud agent vers le noeud ma&icirc;tre.
     <br/>
     Bien &eacute;videmment, aucune copie ne sera effectu&eacute;e si le build
     s'effectue sur le noeud ma&icirc;tre.


### PR DESCRIPTION
The word esclave(s) appeared in the French documentation for the copy-to-slave plugin; I changed it to agent(s) (consistent with previous PRs).