### PR TITLE
Hacktoberfest - Cleanup "Slave" references in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,14 @@
-Copy To Slave plugin
+Copy To Agent plugin
 ====================
 Copyright &copy; 2009-2011, Manufacture Française des Pneumatiques Michelin, Romain Seguy, and other contributors. Licensed under MIT License.
 
 About this plugin
 -----------------
-The Copy To Slave plugin is meant to be used from [Jenkins][2] to provide a way to copy files located somewhere on Jenkins' master node to the jobs' workspaces. Please take a look at [Jenkins' wiki][3] to get detailed information.
+The Copy To Agent plugin is meant to be used from [Jenkins][2] to provide a way to copy files located somewhere on Jenkins' master node to the jobs' workspaces. Please take a look at [Jenkins' wiki][3] to get detailed information.
 
 Installation
 ------------
-The Copy To Slave plugin can be installed from any Jenkins installation connected to the Internet using the **Plugin Manager** screen.
-
-Source code
------------
-The primary location for the source code of this plugin is on [Jenkins' SVN repository][4]. It is also mirrored on [GitHub][5] for conveniency.
+The Copy To Agent plugin can be installed from any Jenkins installation connected to the Internet using the **Plugin Manager** screen.
 
 [2]: http://jenkins-ci.org/
 [3]: http://wiki.jenkins-ci.org/display/JENKINS/Copy+To+Slave+Plugin
-[4]: https://svn.jenkins-ci.org/trunk/hudson/plugins/copy-to-slave/
-[5]: https://github.com/jenkinsci/copy-to-slave-plugin


### PR DESCRIPTION
This PR cleans up the plugin readme. The plugin itself still needs to be renamed to "Copy to Agent"